### PR TITLE
Fix warning and error in example code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ harness = false
 Next, define a benchmark by creating a file at `$PROJECT/benches/my_benchmark.rs` with the following contents:
 
 ```rust
-use iai::{black_box, main};
+use iai::black_box;
 
 fn fibonacci(n: u64) -> u64 {
     match n {
@@ -74,7 +74,7 @@ fn iai_benchmark_short() -> u64 {
 }
 
 fn iai_benchmark_long() -> u64 {
-    fibonacci(black_box(30));
+    fibonacci(black_box(30))
 }
 
 


### PR DESCRIPTION
```
warning: unused import: `main`
 --> benches/my_benchmark.rs:1:22
  |
1 | use iai::{black_box, main};
  |                      ^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

error[E0308]: mismatched types
  --> benches/my_benchmark.rs:15:28
   |
15 | fn iai_benchmark_long() -> u64 {
   |    ------------------      ^^^ expected `u64`, found `()`
   |    |
   |    implicitly returns `()` as its body has no tail or `return` expression
16 |     fibonacci(black_box(30));
   |                             - help: consider removing this semicolon

error: aborting due to previous error; 1 warning emitted

For more information about this error, try `rustc --explain E0308`.
```