### PR TITLE
Allow invoking iai benchmarks on FreeBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["development-tools::profiling"]
 license = "Apache-2.0/MIT"
 
 [dependencies]
+cfg-if = "1.0"
 iai_macro = { version = "0.1.0", path = "macro", optional = true }
 
 [features]


### PR DESCRIPTION
Disabling ASLR is platform-specific.

Fixes #9