### PR TITLE
Allow for benchmark setup code

### DIFF
--- a/benches/test_regular_bench.rs
+++ b/benches/test_regular_bench.rs
@@ -1,4 +1,4 @@
-use iai::black_box;
+use iai::{black_box, Iai};
 
 fn fibonacci(n: u64) -> u64 {
     match n {
@@ -7,16 +7,19 @@ fn fibonacci(n: u64) -> u64 {
     }
 }
 
-fn bench_empty() {
-    return;
+fn bench_empty(iai: &mut Iai) {
+    iai.run(|| {
+        return;
+    });
 }
 
-fn bench_fibonacci() -> u64 {
-    fibonacci(black_box(10))
+fn bench_fibonacci(iai: &mut Iai) {
+    iai.run(|| fibonacci(black_box(10)));
 }
 
-fn bench_fibonacci_long() -> u64 {
-    fibonacci(black_box(30))
+fn bench_fibonacci_long(iai: &mut Iai) {
+    let target = black_box(2_u64.pow(4) + 7 * 2); // 30
+    iai.run(|| fibonacci(black_box(target)));
 }
 
 iai::main!(bench_empty, bench_fibonacci, bench_fibonacci_long);

--- a/macro/benches/test_macro_bench.rs
+++ b/macro/benches/test_macro_bench.rs
@@ -2,7 +2,7 @@
 #![test_runner(iai::runner)]
 
 use iai::black_box;
-use iai::iai;
+use iai::{iai, Iai};
 
 fn fibonacci(n: u64) -> u64 {
     match n {
@@ -12,16 +12,19 @@ fn fibonacci(n: u64) -> u64 {
 }
 
 #[iai]
-fn bench_empty() {
-    return;
+fn bench_empty(iai: &mut Iai) {
+    iai.run(|| {
+        return;
+    });
 }
 
 #[iai]
-fn bench_fibonacci() -> u64 {
-    fibonacci(black_box(10))
+fn bench_fibonacci(iai: &mut Iai) {
+    iai.run(|| fibonacci(black_box(10)));
 }
 
 #[iai]
-fn bench_fibonacci_long() -> u64 {
-    fibonacci(black_box(30))
+fn bench_fibonacci_long(iai: &mut Iai) {
+    let target = black_box(2_u64.pow(4) + 7 * 2); // 30
+    iai.run(|| fibonacci(black_box(target)));
 }

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -17,12 +17,12 @@ pub fn iai(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let output = quote_spanned!(span=>
         #item
 
-        fn #wrapper_function_name() {
-            let _ = iai::black_box(#function_name());
+        fn #wrapper_function_name(iai: &mut iai::Iai) {
+            let _ = iai::black_box(#function_name(iai));
         }
 
         #[test_case]
-        const #const_name : (&'static str, fn()) = (#name_literal, #wrapper_function_name);
+        const #const_name : (&'static str, fn(&mut iai::Iai)) = (#name_literal, #wrapper_function_name);
     );
 
     output.into()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,7 +359,16 @@ pub fn runner(benches: &[&(&'static str, fn(&mut Iai))]) {
 
     let allow_aslr = std::env::var_os("IAI_ALLOW_ASLR").is_some();
 
+    let filtered: Vec<_> = args().skip(1).filter(|arg| !arg.starts_with("--")).collect();
+
     for (i, (name, _func)) in benches.iter().enumerate() {
+        // If filter arguments were passed on the command line, only run the
+        // benchmarks which contain any of the filtered words as substrings of
+        // their names.
+        if !filtered.is_empty() && !filtered.iter().any(|s| name.contains(s)) {
+            continue;
+        }
+
         println!("{}", name);
         let setup_name = name.to_string() + "_setup";
         let i = i as isize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,52 @@ pub use iai_macro::iai;
 
 mod macros;
 
+/// The benchmark manager.
+///
+/// This struct runs and tracks your benchmarks. A reference to it is obtained
+/// by passing your benchmark function to the [`iai::main`](crate::main) macro.
+/// The signature of functions passed to it should thus be `fn my_bench(iai:
+/// &mut Iai)`. In your benchmark functions, run any setup code you need, and
+/// then call `iai.run` with a closure containing the code you want to measure.
+///
+/// Iai will measure your function twice, once without actually running the
+/// measurement closure such that the impact of the setup code can be excluded.
+///
+/// Every benchmark function has to call `iai.run` exactly least once.
+pub struct Iai {
+    /// Whether the benchmark already (should have) been run, regardless of the
+    /// current `only_runs_setup` mode.
+    ran: bool,
+    /// Whether only setup code or also the benchmark code will be run.
+    only_runs_setup: bool,
+}
+
+impl Iai {
+    fn new(only_runs_setup: bool) -> Self {
+        Self {
+            ran: false,
+            only_runs_setup,
+        }
+    }
+
+    /// Runs the benchmark function.
+    ///
+    /// # Panics
+    /// Panics if the method is called more than once.
+    pub fn run<F, U>(&mut self, mut func: F)
+    where
+        F: FnMut() -> U,
+    {
+        if self.ran {
+            panic!("the run method may only be called once");
+        }
+        self.ran = true;
+        if !self.only_runs_setup {
+            black_box(func());
+        }
+    }
+}
+
 /// A function that is opaque to the optimizer, used to prevent the compiler from
 /// optimizing away computations in a benchmark.
 ///
@@ -114,6 +160,7 @@ fn run_bench(
     executable: &str,
     i: isize,
     name: &str,
+    setup_only: bool,
     allow_aslr: bool,
 ) -> (CachegrindStats, Option<CachegrindStats>) {
     let output_file = PathBuf::from(format!("target/iai/cachegrind.out.{}", name));
@@ -130,8 +177,8 @@ fn run_bench(
     } else {
         valgrind_without_aslr(arch)
     };
-    let status = cmd
-        .arg("--tool=cachegrind")
+
+    cmd.arg("--tool=cachegrind")
         // Set some reasonable cache sizes. The exact sizes matter less than having fixed sizes,
         // since otherwise cachegrind would take them from the CPU and make benchmark runs
         // even more incomparable between machines.
@@ -141,7 +188,15 @@ fn run_bench(
         .arg(format!("--cachegrind-out-file={}", output_file.display()))
         .arg(executable)
         .arg("--iai-run")
-        .arg(i.to_string())
+        .arg(i.to_string());
+
+    // If this argument is set, we only run the setup code without the
+    // actual benchmark payload.
+    if setup_only {
+        cmd.arg("--iai-setup");
+    }
+
+    let status = cmd
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
@@ -226,10 +281,10 @@ impl CachegrindStats {
         let ram_hits = self.ram_accesses();
         let l3_accesses =
             self.instruction_l1_misses + self.data_l1_read_misses + self.data_l1_write_misses;
-        let l3_hits = l3_accesses - ram_hits;
+        let l3_hits = l3_accesses.saturating_sub(ram_hits);
 
         let total_memory_rw = self.instruction_reads + self.data_reads + self.data_writes;
-        let l1_hits = total_memory_rw - (ram_hits + l3_hits);
+        let l1_hits = total_memory_rw.saturating_sub(ram_hits + l3_hits);
 
         CachegrindSummary {
             l1_hits,
@@ -269,7 +324,7 @@ impl CachegrindSummary {
 
 /// Custom-test-framework runner. Should not be called directly.
 #[doc(hidden)]
-pub fn runner(benches: &[&(&'static str, fn())]) {
+pub fn runner(benches: &[&(&'static str, fn(&mut Iai))]) {
     let mut args_iter = args();
     let executable = args_iter.next().unwrap();
 
@@ -278,15 +333,20 @@ pub fn runner(benches: &[&(&'static str, fn())]) {
         // possible and exit
         let index: isize = args_iter.next().unwrap().parse().unwrap();
 
-        // -1 is used as a signal to do nothing and return. By recording an empty benchmark, we can
-        // subtract out the overhead from startup and dispatching to the right benchmark.
-        if index == -1 {
-            return;
-        }
+        // The `--iai-setup` argument is a special signal to indicate that
+        // only setup routines should be run. By recording an empty benchmark,
+        // we can subtract out the overhead from setup and dispatching to the
+        // right benchmark.
+        let only_runs_setup = matches!(args_iter.next().as_deref(), Some("--iai-setup"));
 
         let index = index as usize;
 
-        (benches[index].1)();
+        let mut iai = Iai::new(only_runs_setup);
+        (benches[index].1)(&mut iai);
+        if !iai.ran {
+            panic!("Benchmark {} did not run", benches[index].0);
+        }
+
         return;
     }
 
@@ -299,12 +359,15 @@ pub fn runner(benches: &[&(&'static str, fn())]) {
 
     let allow_aslr = std::env::var_os("IAI_ALLOW_ASLR").is_some();
 
-    let (calibration, old_calibration) =
-        run_bench(&arch, &executable, -1, "iai_calibration", allow_aslr);
-
     for (i, (name, _func)) in benches.iter().enumerate() {
         println!("{}", name);
-        let (stats, old_stats) = run_bench(&arch, &executable, i as isize, name, allow_aslr);
+        let setup_name = name.to_string() + "_setup";
+        let i = i as isize;
+
+        let (calibration, old_calibration) =
+            run_bench(&arch, &executable, i, &setup_name, true, allow_aslr);
+        let (stats, old_stats) = run_bench(&arch, &executable, i, name, false, allow_aslr);
+
         let (stats, old_stats) = (
             stats.subtract(&calibration),
             match (&old_stats, &old_calibration) {


### PR DESCRIPTION
This PR allows to include setup code for each benchmark that will be excluded by the measurement.
It achieves this by running each benchmark twice, once with, and once without the user's setup code. The setup runtime can then be excluded from the final figures. A Criterion-like task runner struct is introduced for this purpose.

Furthermore, the PR contains a small feature that allows filtering the benchmarks by name on the command line.

Merging this would close #20 and #23.