### PR TITLE
Use Callgrind instead of Cachegrind

### DIFF
--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -10,13 +10,16 @@ pub fn iai(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let span = proc_macro2::Span::call_site();
 
     let function_name = find_name(item.clone());
-    let wrapper_function_name = Ident::new(&format!("wrap_{}", function_name.to_string()), span);
+    let wrapper_function_name =
+        Ident::new(&format!("__iai_bench_{}", function_name.to_string()), span);
     let const_name = Ident::new(&format!("IAI_FUNC_{}", function_name.to_string()), span);
     let name_literal = function_name.to_string();
 
     let output = quote_spanned!(span=>
         #item
 
+        #[no_mangle]
+        #[inline(never)]
         fn #wrapper_function_name() {
             let _ = iai::black_box(#function_name());
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,8 +156,6 @@ fn run_benches(
     let status = cmd
         .arg(executable)
         .arg("--iai-run")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
         .status()
         .expect("Failed to run benchmark in callgrind");
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -38,6 +38,9 @@ macro_rules! main {
     ( $( $func_name:ident ),+ $(,)* ) => {
         mod iai_wrappers {
             $(
+                #[no_mangle]
+                #[inline(never)]
+                #[export_name = concat!("__iai_bench_", stringify!($func_name))]
                 pub fn $func_name() {
                     let _ = $crate::black_box(super::$func_name());
                 }


### PR DESCRIPTION
Quick draft, willing to put the work in to making this PR prettier if this transition desired, @bheisler?

Using Callgrind makes the output even more stable, since we no longer need to do an initial calibration run, so any setup that the OS linker has to perform is never included in the output. This is especially important when using valgrind on macOS (see https://github.com/bheisler/iai/issues/25#issuecomment-1029462079), since the linker does more work at runtime there.

See [Callgrind docs](https://valgrind.org/docs/manual/cl-manual.html) for more info.

Could also be part of fixing https://github.com/bheisler/iai/issues/7, https://github.com/bheisler/iai/issues/20 and https://github.com/bheisler/iai/issues/23.